### PR TITLE
Use android_hardware_qcom_audio-caf from Team-Hydra

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -273,7 +273,7 @@
   <project path="hardware/libhardware_legacy" name="Team-Hydra/android_hardware_libhardware_legacy" />
   <project path="hardware/msm7k" name="CyanogenMod/android_hardware_msm7k" />
   <project path="hardware/qcom/audio" name="CyanogenMod/android_hardware_qcom_audio" />
-  <project path="hardware/qcom/audio-caf" name="CyanogenMod/android_hardware_qcom_audio-caf" />
+  <project path="hardware/qcom/audio-caf" name="Team-Hydra/android_hardware_qcom_audio-caf" />
   <project path="hardware/qcom/bt" name="CyanogenMod/android_hardware_qcom_bt" />
   <project path="hardware/qcom/camera" name="CyanogenMod/android_hardware_qcom_camera" />
   <project path="hardware/qcom/display" name="CyanogenMod/android_hardware_qcom_display" />


### PR DESCRIPTION
This pulls in a commit that was added to the Team-Hydra fork of android_hardware_qcom_audio-caf that fixes mic input on pyramid.
